### PR TITLE
fix: v0.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.2] - 2025-12-07
+
+### Fixed
+
+- Vinyl record now spins immediately on first play (previously required double click)
+- CSS `@import` order warning from PostCSS (moved Google Fonts import to top of file)
+- README documentation now uses `127.0.0.1` instead of `localhost` for Spotify redirect URI
+
+### Changed
+
+- New lofi-style favicon (vinyl record with tomato/pomodoro center)
+
 ## [0.0.1] - 2025-12-07
 
 ### Added
@@ -26,4 +38,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Spotify Web API integration for playback control
 - JSDoc documentation throughout codebase
 
+[0.0.2]: https://github.com/davidlbowman/spotify-pomodoro/releases/tag/v0.0.2
 [0.0.1]: https://github.com/davidlbowman/spotify-pomodoro/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ bun install
 3. Fill in the details:
    - **App name:** Spotify Pomodoro (or whatever you prefer)
    - **App description:** Pomodoro timer with Spotify
-   - **Redirect URI:** `http://localhost:4321/callback`
+   - **Redirect URI:** `http://127.0.0.1:4321/callback`
    - **APIs used:** Check "Web API"
 4. Click "Save"
 5. In your app's settings, copy the **Client ID**
@@ -45,7 +45,7 @@ Create a `.env` file in the project root:
 
 ```bash
 PUBLIC_SPOTIFY_CLIENT_ID=your_client_id_here
-PUBLIC_SPOTIFY_REDIRECT_URI=http://localhost:4321/callback
+PUBLIC_SPOTIFY_REDIRECT_URI=http://127.0.0.1:4321/callback
 ```
 
 Replace `your_client_id_here` with the Client ID from step 2.

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,9 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 128 128">
-    <path d="M50.4 78.5a75.1 75.1 0 0 0-28.5 6.9l24.2-65.7c.7-2 1.9-3.2 3.4-3.2h29c1.5 0 2.7 1.2 3.4 3.2l24.2 65.7s-11.6-7-28.5-7L67 45.5c-.4-1.7-1.6-2.8-2.9-2.8-1.3 0-2.5 1.1-2.9 2.7L50.4 78.5Zm-1.1 28.2Zm-4.2-20.2c-2 6.6-.6 15.8 4.2 20.2a17.5 17.5 0 0 1 .2-.7 5.5 5.5 0 0 1 5.7-4.5c2.8.1 4.3 1.5 4.7 4.7.2 1.1.2 2.3.2 3.5v.4c0 2.7.7 5.2 2.2 7.4a13 13 0 0 0 5.7 4.9v-.3l-.2-.3c-1.8-5.6-.5-9.5 4.4-12.8l1.5-1a73 73 0 0 0 3.2-2.2 16 16 0 0 0 6.8-11.4c.3-2 .1-4-.6-6l-.8.6-1.6 1a37 37 0 0 1-22.4 2.7c-5-.7-9.7-2-13.2-6.2Z" />
-    <style>
-        path { fill: #000; }
-        @media (prefers-color-scheme: dark) {
-            path { fill: #FFF; }
-        }
-    </style>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="tomato" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff6b6b"/>
+      <stop offset="100%" stop-color="#c92a2a"/>
+    </linearGradient>
+  </defs>
+  <!-- Vinyl record outer ring -->
+  <circle cx="16" cy="16" r="14" fill="#1a1a2e"/>
+  <circle cx="16" cy="16" r="12" fill="none" stroke="#2d2d44" stroke-width="0.5"/>
+  <circle cx="16" cy="16" r="10" fill="none" stroke="#2d2d44" stroke-width="0.5"/>
+  <circle cx="16" cy="16" r="8" fill="none" stroke="#2d2d44" stroke-width="0.5"/>
+  <!-- Center tomato/pomodoro -->
+  <circle cx="16" cy="16" r="5" fill="url(#tomato)"/>
+  <!-- Tomato stem -->
+  <path d="M16 11 Q14 9 15 8 Q16 7 17 8 Q18 9 16 11" fill="#2d5a27"/>
+  <!-- Subtle highlight -->
+  <ellipse cx="14" cy="14" rx="1.5" ry="1" fill="rgba(255,255,255,0.2)"/>
 </svg>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -40,6 +40,7 @@ export function App() {
 		null,
 	);
 	const [showPlaylists, setShowPlaylists] = useState(false);
+	const [isPlayingIntent, setIsPlayingIntent] = useState(false);
 	const inputRef = useRef<HTMLInputElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 
@@ -66,6 +67,12 @@ export function App() {
 			fetchPlaylists();
 		}
 	}, [isAuthenticated, fetchPlaylists]);
+
+	useEffect(() => {
+		if (playbackState) {
+			setIsPlayingIntent(playbackState.isPlaying);
+		}
+	}, [playbackState]);
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
@@ -144,15 +151,18 @@ export function App() {
 	const handlePlaylistSelect = async (playlist: Playlist) => {
 		setSelectedPlaylist(playlist);
 		setShowPlaylists(false);
+		setIsPlayingIntent(true);
 		await play({ contextUri: playlist.uri });
 		await setShuffle(true);
 		await setRepeat("context");
 	};
 
 	const handlePlayPause = async () => {
-		if (isPlaying) {
+		if (isPlaying || isPlayingIntent) {
+			setIsPlayingIntent(false);
 			await pauseMusic();
 		} else if (selectedPlaylist) {
+			setIsPlayingIntent(true);
 			await play({ contextUri: selectedPlaylist.uri });
 		}
 	};
@@ -329,8 +339,9 @@ export function App() {
 									<div
 										className={cn(
 											"w-[4.5rem] h-[4.5rem] rounded-full bg-[var(--lofi-vinyl)] border border-border",
-											isPlaying && "animate-spin-slow",
+											(isPlaying || isPlayingIntent) && "animate-spin-slow",
 											!isPlaying &&
+												!isPlayingIntent &&
 												selectedPlaylist &&
 												"animate-spin-slow paused",
 										)}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,11 +1,10 @@
+@import url('https://fonts.googleapis.com/css2?family=Lexend:wght@300;400;500&family=Space+Mono:wght@400;700&display=swap');
 @import "tailwindcss";
 @import "tw-animate-css";
 
 /* Lofi Pomodoro - Refined minimal timer */
 
 @custom-variant dark (&:is(.dark *));
-
-@import url('https://fonts.googleapis.com/css2?family=Lexend:wght@300;400;500&family=Space+Mono:wght@400;700&display=swap');
 
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);


### PR DESCRIPTION
## Summary

- Fix vinyl record not spinning on first play (closes #3)
- Fix README redirect URI documentation to use `127.0.0.1` instead of `localhost` (closes #2)
- Fix CSS `@import` order warning from PostCSS
- Add lofi-style favicon with vinyl/tomato design (closes #4)

## Changes

| File | Change |
|------|--------|
| `src/components/App.tsx` | Added `isPlayingIntent` state to trigger vinyl spin immediately |
| `README.md` | Changed redirect URI from `localhost` to `127.0.0.1` |
| `src/styles/global.css` | Moved Google Fonts import to top of file |
| `public/favicon.svg` | New lofi favicon (vinyl record with tomato center) |
| `CHANGELOG.md` | Added v0.0.2 release notes |

## Test plan

- [x] Verify vinyl spins immediately when selecting a playlist
- [x] Verify no CSS warnings in dev console
- [x] Verify favicon displays correctly in browser tab