### PR TITLE
fix: v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2025-12-10
+
+### Fixed
+
+- PKCE challenge not found error on initial Spotify authentication (#7)
+- Spotify autoplay not working when Spotify app is already open but paused (#8)
+- AudioContext autoplay policy warning in browser console
+
+### Changed
+
+- Development server now runs on port 2500
+- AudioContext is lazy-initialized on first timer completion instead of on page load
+
+### Dependencies
+
+- Updated lucide-react
+
 ## [0.0.2] - 2025-12-07
 
 ### Fixed
@@ -38,5 +55,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Spotify Web API integration for playback control
 - JSDoc documentation throughout codebase
 
+[0.1.0]: https://github.com/davidlbowman/spotify-pomodoro/releases/tag/v0.1.0
 [0.0.2]: https://github.com/davidlbowman/spotify-pomodoro/releases/tag/v0.0.2
 [0.0.1]: https://github.com/davidlbowman/spotify-pomodoro/releases/tag/v0.0.1

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,11 +1,12 @@
-// @ts-check
-
 import react from "@astrojs/react";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 
 // https://astro.build/config
 export default defineConfig({
+	server: {
+		port: 2500,
+	},
 	vite: {
 		plugins: [tailwindcss()],
 	},

--- a/bun.lock
+++ b/bun.lock
@@ -17,8 +17,8 @@
         "astro": "^5.16.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "effect": "^3.19.9",
-        "lucide-react": "^0.556.0",
+        "effect": "^3.19.10",
+        "lucide-react": "^0.557.0",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
         "tailwind-merge": "^3.4.0",
@@ -612,7 +612,7 @@
 
     "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
 
-    "effect": ["effect@3.19.9", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-taMXnfG/p+j7AmMOHHQaCHvjqwu9QBO3cxuZqL2dMG/yWcEMw0ZHruHe9B49OxtfKH/vKKDDKRhZ+1GJ2p5R5w=="],
+    "effect": ["effect@3.19.10", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-kT1vSSUIgTPNOOFnnqWwb0xb7K/VYuMFOoMOm71wYv3VJGcFMl3ojCdCCKtiiGqn8fMQPk7Fl9bBShQO6bgyFg=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.266", "", {}, "sha512-kgWEglXvkEfMH7rxP5OSZZwnaDWT7J9EoZCujhnpLbfi0bbNtRkgdX2E3gt0Uer11c61qCYktB3hwkAS325sJg=="],
 
@@ -770,7 +770,7 @@
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "lucide-react": ["lucide-react@0.556.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-iOb8dRk7kLaYBZhR2VlV1CeJGxChBgUthpSP8wom9jfj79qovgG6qcSdiy6vkoREKPnbUYzJsCn4o4PtG3Iy+A=="],
+    "lucide-react": ["lucide-react@0.557.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-x6LrJAuYGywdjH4rBgI8ygWnCsn8GTvS9/BhSORNWsuv3LNLV39ZOUg6UTJa9nFUl0fHY8bytDSThH12pNHyLQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "spotify-pomodoro",
 	"type": "module",
-	"version": "0.0.1",
+	"version": "0.1.0",
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro build",
@@ -25,8 +25,8 @@
 		"astro": "^5.16.4",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
-		"effect": "^3.19.9",
-		"lucide-react": "^0.556.0",
+		"effect": "^3.19.10",
+		"lucide-react": "^0.557.0",
 		"react": "^19.2.1",
 		"react-dom": "^19.2.1",
 		"tailwind-merge": "^3.4.0",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -28,6 +28,7 @@ export function App() {
 	const { playlists, fetchPlaylists } = useSpotifyPlaylists();
 	const {
 		playbackState,
+		fetchPlaybackState,
 		play,
 		pause: pauseMusic,
 		setShuffle,
@@ -65,8 +66,9 @@ export function App() {
 	useEffect(() => {
 		if (isAuthenticated) {
 			fetchPlaylists();
+			fetchPlaybackState();
 		}
-	}, [isAuthenticated, fetchPlaylists]);
+	}, [isAuthenticated, fetchPlaylists, fetchPlaybackState]);
 
 	useEffect(() => {
 		if (playbackState) {

--- a/src/effect/services/SpotifyClient.ts
+++ b/src/effect/services/SpotifyClient.ts
@@ -167,7 +167,11 @@ export class SpotifyClient extends Effect.Service<SpotifyClient>()(
 				}),
 			);
 
-			const play = (options?: { contextUri?: string; uris?: string[] }) =>
+			const play = (options?: {
+				contextUri?: string;
+				uris?: string[];
+				deviceId?: string;
+			}) =>
 				authorizedFetch((accessToken) =>
 					Effect.gen(function* () {
 						const body = options?.contextUri
@@ -176,9 +180,11 @@ export class SpotifyClient extends Effect.Service<SpotifyClient>()(
 								? { uris: options.uris }
 								: {};
 
-						const request = HttpClientRequest.put(
-							`${SPOTIFY_API_BASE}/me/player/play`,
-						).pipe(
+						const url = options?.deviceId
+							? `${SPOTIFY_API_BASE}/me/player/play?device_id=${options.deviceId}`
+							: `${SPOTIFY_API_BASE}/me/player/play`;
+
+						const request = HttpClientRequest.put(url).pipe(
 							HttpClientRequest.setHeader(
 								"Authorization",
 								`Bearer ${accessToken}`,

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -28,8 +28,6 @@ export function useTimer() {
 			const timer = yield* Timer;
 			const audio = yield* AudioNotification;
 
-			yield* audio.init;
-
 			yield* timer.setOnTimerEnd(() => {
 				runEffect(audio.play);
 			});


### PR DESCRIPTION
## Summary

- Fix PKCE challenge not found error on initial Spotify authentication
- Fix Spotify autoplay not working when app is already open but paused
- Fix AudioContext autoplay policy warning

## Changes

### Bug Fixes
- **PKCE Auth (#7)**: Wrap sessionStorage retrieval in Effect.try for proper error handling
- **Autoplay (#8)**: Pass device_id to Spotify play API when available, track last known device ID
- **AudioContext**: Lazy-initialize on first timer completion instead of on mount

### Other
- Remove ts-check from astro.config.mjs to fix Vite type mismatch
- Configure development server port to 2500
- Update lucide-react dependency

## Test plan

- [x] Clear localStorage/sessionStorage, authenticate with Spotify - no PKCE error
- [x] Open Spotify app, pause playback, select playlist in app - autoplay works
- [x] Load page fresh - no AudioContext console warning
- [x] Build passes
- [x] Typecheck passes

Closes #7
Closes #8