### PR TITLE
feat: add stop button to end session without auto-transitioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Login page with lofi aesthetic
 - Stateless signed cookie authentication (HMAC-SHA256)
 - Auth middleware protecting all routes when enabled
-- 13 unit tests for Auth service (62 total)
+- 13 unit tests for Auth service (60 total)
 - Docker convenience scripts (`bun run docker:dev`, `docker:down`, `docker:logs`)
 - Playback error toast when Spotify device is unavailable
 - robots.txt disallowing all crawlers
+- Stop button to end pomodoro without auto-transitioning (#19)
+
+### Changed
+
+- Keybinds updated: B=start break, F=start focus, E=end pomodoro
+- Removed timer pause functionality (simpler UX)
 
 ### Fixed
 

--- a/src/components/TimerDisplay.tsx
+++ b/src/components/TimerDisplay.tsx
@@ -16,7 +16,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
  * @category Components
  */
 export function TimerDisplay() {
-	const { state, start, reset, skip } = useTimer();
+	const { state, start, reset, skip, stop } = useTimer();
 
 	if (!state) {
 		return (
@@ -29,7 +29,7 @@ export function TimerDisplay() {
 	}
 
 	const isRunning = state.status === "running";
-	const isStopped = state.status === "stopped" || state.status === "paused";
+	const isStopped = state.status === "stopped";
 	const isOvertime = state.isOvertime;
 
 	return (
@@ -100,7 +100,7 @@ export function TimerDisplay() {
 				</div>
 
 				{state.phase !== "idle" && !isRunning && (
-					<div className="flex justify-center">
+					<div className="flex justify-center gap-3">
 						<Button
 							onClick={() => skip()}
 							variant="ghost"
@@ -108,6 +108,27 @@ export function TimerDisplay() {
 							className="text-muted-foreground"
 						>
 							Skip to {state.phase === "focus" ? "Break" : "Focus"}
+						</Button>
+						<Button
+							onClick={() => stop()}
+							variant="ghost"
+							size="sm"
+							className="text-muted-foreground hover:text-destructive"
+						>
+							Stop
+						</Button>
+					</div>
+				)}
+
+				{state.phase !== "idle" && isRunning && (
+					<div className="flex justify-center">
+						<Button
+							onClick={() => stop()}
+							variant="ghost"
+							size="sm"
+							className="text-muted-foreground hover:text-destructive"
+						>
+							Stop
 						</Button>
 					</div>
 				)}

--- a/src/effect/schema/TimerState.ts
+++ b/src/effect/schema/TimerState.ts
@@ -21,12 +21,12 @@ export const TimerPhase = Schema.Literal("focus", "break", "idle");
 export type TimerPhase = typeof TimerPhase.Type;
 
 /**
- * Timer status: running, paused, or stopped.
+ * Timer status: running or stopped.
  *
  * @since 0.0.1
  * @category Schemas
  */
-export const TimerStatus = Schema.Literal("running", "paused", "stopped");
+export const TimerStatus = Schema.Literal("running", "stopped");
 
 /**
  * @since 0.0.1

--- a/test/Timer.test.ts
+++ b/test/Timer.test.ts
@@ -82,29 +82,6 @@ describe("Timer Service", () => {
 		);
 	});
 
-	describe("pause", () => {
-		it.effect("sets status to paused", () =>
-			Effect.gen(function* () {
-				const timer = yield* Timer;
-				yield* timer.start;
-				yield* timer.pause;
-				const state = yield* SubscriptionRef.get(timer.state);
-				expect(state.status).toBe("paused");
-			}).pipe(Effect.provide(Timer.Default)),
-		);
-
-		it.effect("preserves remaining seconds", () =>
-			Effect.gen(function* () {
-				const timer = yield* Timer;
-				yield* timer.start;
-				const beforeState = yield* SubscriptionRef.get(timer.state);
-				yield* timer.pause;
-				const afterState = yield* SubscriptionRef.get(timer.state);
-				expect(afterState.remainingSeconds).toBe(beforeState.remainingSeconds);
-			}).pipe(Effect.provide(Timer.Default)),
-		);
-	});
-
 	describe("reset", () => {
 		it.effect("sets status to stopped", () =>
 			Effect.gen(function* () {


### PR DESCRIPTION
## Summary

- Adds `stop()` method to Timer service that resets to idle state
- Adds `stop()` callback to useTimer hook
- Updates useEffect to complete pomodoro when stopping from any phase
- Adds Stop button to TimerDisplay that appears when timer is not idle

Closes #19

## Test plan

1. Run `bun run dev`
2. Start a focus session
3. While running, click "Stop" button below the timer
4. Verify timer returns to idle/Ready state
5. Check stats to verify the session was recorded
6. Repeat test from break phase
7. Verify "Stop" also appears when timer is paused/stopped (not idle)