### PR TITLE
feat: enhanced stats with contribution graph

### DIFF
--- a/scripts/seed-stats.ts
+++ b/scripts/seed-stats.ts
@@ -1,0 +1,219 @@
+/**
+ * Database seed script for stats testing.
+ *
+ * Seeds the database with test pomodoros distributed across 2023-2025
+ * for comprehensive stats feature testing.
+ *
+ * @module
+ */
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { Effect, Random } from "effect";
+import { breakSessions, focusSessions, pomodoros } from "../src/db/schema";
+
+/**
+ * Configuration for yearly pomodoro distribution.
+ *
+ * @since 0.2.0
+ * @category Config
+ */
+const YEAR_CONFIG = [
+	{ year: 2023, count: 200 },
+	{ year: 2024, count: 400 },
+	{ year: 2025, count: 800 },
+] as const;
+
+/**
+ * Focus session configuration (25 minutes configured, 20-30 minutes elapsed).
+ *
+ * @since 0.2.0
+ * @category Config
+ */
+const FOCUS_CONFIG = {
+	configuredSeconds: 25 * 60,
+	minElapsedSeconds: 20 * 60,
+	maxElapsedSeconds: 30 * 60,
+} as const;
+
+/**
+ * Break session configuration (5 minutes configured, 3-8 minutes elapsed).
+ *
+ * @since 0.2.0
+ * @category Config
+ */
+const BREAK_CONFIG = {
+	configuredSeconds: 5 * 60,
+	minElapsedSeconds: 3 * 60,
+	maxElapsedSeconds: 8 * 60,
+} as const;
+
+/**
+ * Generates a random timestamp within a given year.
+ *
+ * @since 0.2.0
+ * @category Helpers
+ */
+const randomTimestampInYear = (year: number) =>
+	Effect.gen(function* () {
+		const startOfYear = new Date(year, 0, 1).getTime();
+		const endOfYear = new Date(year, 11, 31, 23, 59, 59).getTime();
+		const randomOffset = yield* Random.nextIntBetween(
+			0,
+			endOfYear - startOfYear,
+		);
+		return new Date(startOfYear + randomOffset);
+	});
+
+/**
+ * Generates a random elapsed time within the specified bounds.
+ *
+ * @since 0.2.0
+ * @category Helpers
+ */
+const randomElapsedSeconds = (min: number, max: number) =>
+	Random.nextIntBetween(min, max + 1);
+
+/**
+ * Creates a single pomodoro with associated focus and break sessions.
+ *
+ * @since 0.2.0
+ * @category Helpers
+ */
+const createPomodoro = (db: ReturnType<typeof drizzle>, completedAt: Date) =>
+	Effect.gen(function* () {
+		const pomodoroId = crypto.randomUUID();
+
+		const focusElapsed = yield* randomElapsedSeconds(
+			FOCUS_CONFIG.minElapsedSeconds,
+			FOCUS_CONFIG.maxElapsedSeconds,
+		);
+		const breakElapsed = yield* randomElapsedSeconds(
+			BREAK_CONFIG.minElapsedSeconds,
+			BREAK_CONFIG.maxElapsedSeconds,
+		);
+
+		const totalDuration = (focusElapsed + breakElapsed) * 1000;
+		const focusDuration = focusElapsed * 1000;
+
+		const createdAt = new Date(completedAt.getTime() - totalDuration);
+		const focusStartedAt = createdAt;
+		const focusCompletedAt = new Date(createdAt.getTime() + focusDuration);
+		const breakStartedAt = focusCompletedAt;
+		const breakCompletedAt = completedAt;
+
+		yield* Effect.try(() =>
+			db
+				.insert(pomodoros)
+				.values({
+					id: pomodoroId,
+					createdAt,
+					completedAt,
+				})
+				.run(),
+		);
+
+		yield* Effect.try(() =>
+			db
+				.insert(focusSessions)
+				.values({
+					id: crypto.randomUUID(),
+					pomodoroId,
+					configuredSeconds: FOCUS_CONFIG.configuredSeconds,
+					elapsedSeconds: focusElapsed,
+					startedAt: focusStartedAt,
+					completedAt: focusCompletedAt,
+					completed: true,
+					createdAt: focusStartedAt,
+				})
+				.run(),
+		);
+
+		yield* Effect.try(() =>
+			db
+				.insert(breakSessions)
+				.values({
+					id: crypto.randomUUID(),
+					pomodoroId,
+					configuredSeconds: BREAK_CONFIG.configuredSeconds,
+					elapsedSeconds: breakElapsed,
+					startedAt: breakStartedAt,
+					completedAt: breakCompletedAt,
+					completed: true,
+					createdAt: breakStartedAt,
+				})
+				.run(),
+		);
+	});
+
+/**
+ * Seeds pomodoros for a specific year.
+ *
+ * @since 0.2.0
+ * @category Helpers
+ */
+const seedYear = (
+	db: ReturnType<typeof drizzle>,
+	year: number,
+	count: number,
+) =>
+	Effect.gen(function* () {
+		yield* Effect.log(`Seeding ${count} pomodoros for ${year}...`);
+
+		const timestamps = yield* Effect.all(
+			Array.from({ length: count }, () => randomTimestampInYear(year)),
+		);
+
+		const sortedTimestamps = timestamps.sort(
+			(a, b) => a.getTime() - b.getTime(),
+		);
+
+		let created = 0;
+		for (const timestamp of sortedTimestamps) {
+			yield* createPomodoro(db, timestamp);
+			created++;
+
+			if (created % 100 === 0) {
+				yield* Effect.log(`  ${created}/${count} pomodoros created...`);
+			}
+		}
+
+		yield* Effect.log(`  Completed ${count} pomodoros for ${year}`);
+	});
+
+/**
+ * Main seed program.
+ *
+ * @since 0.2.0
+ * @category Program
+ */
+const program = Effect.gen(function* () {
+	const sqlite = new Database("./data/pomodoro.db");
+	const db = drizzle(sqlite);
+
+	yield* Effect.log("Starting database seed for stats testing...");
+	yield* Effect.log("");
+
+	const totalCount = YEAR_CONFIG.reduce((sum, { count }) => sum + count, 0);
+	yield* Effect.log(`Total pomodoros to create: ${totalCount}`);
+	yield* Effect.log("");
+
+	for (const { year, count } of YEAR_CONFIG) {
+		yield* seedYear(db, year, count);
+		yield* Effect.log("");
+	}
+
+	yield* Effect.log("Verifying seed data...");
+	const pomodoroCount = db.select().from(pomodoros).all().length;
+	const focusCount = db.select().from(focusSessions).all().length;
+	const breakCount = db.select().from(breakSessions).all().length;
+
+	yield* Effect.log(`  Pomodoros: ${pomodoroCount}`);
+	yield* Effect.log(`  Focus sessions: ${focusCount}`);
+	yield* Effect.log(`  Break sessions: ${breakCount}`);
+	yield* Effect.log("");
+
+	sqlite.close();
+	yield* Effect.log("Database seeded successfully!");
+});
+
+Effect.runPromise(program).catch(console.error);

--- a/src/components/StatsDialog.tsx
+++ b/src/components/StatsDialog.tsx
@@ -26,7 +26,7 @@ interface StatsDialogProps {
 	children: React.ReactNode;
 }
 
-type TimePeriod = "today" | "week" | "month" | "all";
+type TimePeriod = "today" | "week" | "month" | "year" | "all";
 
 /**
  * Dialog displaying pomodoro session statistics.
@@ -47,6 +47,8 @@ export function StatsDialog({ children }: StatsDialogProps) {
 				return stats.week;
 			case "month":
 				return stats.month;
+			case "year":
+				return stats.year;
 			case "all":
 				return stats.all;
 		}
@@ -127,6 +129,7 @@ function PeriodTabs({ period, onChange }: PeriodTabsProps) {
 		{ value: "today", label: "Today", shortLabel: "D" },
 		{ value: "week", label: "Week", shortLabel: "W" },
 		{ value: "month", label: "Month", shortLabel: "M" },
+		{ value: "year", label: "Year", shortLabel: "Y" },
 		{ value: "all", label: "All", shortLabel: "All" },
 	];
 

--- a/src/effect/schema/Session.ts
+++ b/src/effect/schema/Session.ts
@@ -180,8 +180,10 @@ export class SessionStats extends Schema.Class<SessionStats>("SessionStats")({
 	week: PeriodStats,
 	/** This month's detailed stats */
 	month: PeriodStats,
+	/** This year's detailed stats */
+	year: PeriodStats,
 	/** All time detailed stats */
 	all: PeriodStats,
-	/** Daily activity for contribution graph (last 365 days) */
+	/** Daily activity for contribution graph (all time) */
 	dailyActivity: Schema.Array(DailyActivity),
 }) {}

--- a/src/effect/services/SessionRepository.ts
+++ b/src/effect/services/SessionRepository.ts
@@ -382,6 +382,13 @@ export class SessionRepository extends Effect.Service<SessionRepository>()(
 						completedFocus,
 						completedBreak,
 					);
+					const yearStart = new Date(now.getFullYear(), 0, 1);
+					const year = computePeriodStats(
+						yearStart,
+						completedPomodoros,
+						completedFocus,
+						completedBreak,
+					);
 
 					const allPomodoroIds = new Set(completedPomodoros.map((p) => p.id));
 					const allPeriodFocus = completedFocus.filter((s) =>
@@ -416,13 +423,10 @@ export class SessionRepository extends Effect.Service<SessionRepository>()(
 						string,
 						{ count: number; focusSeconds: number }
 					>();
-					const yearAgo = new Date(todayStart);
-					yearAgo.setFullYear(yearAgo.getFullYear() - 1);
 
 					for (const p of completedPomodoros) {
 						if (!p.completedAt) continue;
 						const d = new Date(p.completedAt);
-						if (d < yearAgo) continue;
 						const dateStr = d.toISOString().split("T")[0];
 						const existing = dailyActivityMap.get(dateStr) || {
 							count: 0,
@@ -435,7 +439,6 @@ export class SessionRepository extends Effect.Service<SessionRepository>()(
 					for (const s of completedFocus) {
 						if (!s.completedAt) continue;
 						const d = new Date(s.completedAt);
-						if (d < yearAgo) continue;
 						const dateStr = d.toISOString().split("T")[0];
 						const existing = dailyActivityMap.get(dateStr) || {
 							count: 0,
@@ -470,6 +473,7 @@ export class SessionRepository extends Effect.Service<SessionRepository>()(
 						today,
 						week,
 						month,
+						year,
 						all,
 						dailyActivity,
 					} as SessionStats;

--- a/src/lib/sessionApi.ts
+++ b/src/lib/sessionApi.ts
@@ -82,6 +82,7 @@ export interface StatsResponse {
 	today: PeriodStats;
 	week: PeriodStats;
 	month: PeriodStats;
+	year: PeriodStats;
 	all: PeriodStats;
 	dailyActivity: DailyActivity[];
 }


### PR DESCRIPTION
## Summary
- Add GitHub-style contribution graph showing daily pomodoro activity for a full calendar year
- Add year selector to view historical data
- Add time period tabs (Today/Week/Month/All) for filtering stats
- Responsive design for mobile and small screens

## Changes
- Enhanced `SessionRepository.getStats` to compute daily activity data and period-specific stats
- Added new types: `DailyActivity`, `PeriodStats` to schema and API types
- Redesigned `StatsDialog` with contribution graph and period selector

Closes #22