### PR TITLE
fix: add Cloudflare Web Analytics manually to avoid SRI error

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,5 +14,6 @@ import { App } from "@/components/App";
 	</head>
 	<body class="min-h-screen bg-background text-foreground antialiased">
 		<App client:load />
+		<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "b99aad9915a64b0a90d4f724e94b0728"}'></script>
 	</body>
 </html>

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -25,5 +25,6 @@ export const prerender = false;
 	</head>
 	<body class="min-h-screen bg-background text-foreground antialiased">
 		<LoginForm client:load returnUrl={returnUrl} />
+		<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "b99aad9915a64b0a90d4f724e94b0728"}'></script>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

- Add Cloudflare Web Analytics script manually to `index.astro` and `login.astro`
- Avoids the SRI (Subresource Integrity) hash mismatch error from Cloudflare's auto-injection

## Problem

Cloudflare's auto-injected script includes an `integrity` attribute with a stale SHA-512 hash. When Cloudflare updates their `beacon.min.js`, the hash no longer matches and browsers block the script:

```
Cross-Origin Request Blocked: ...cloudflareinsights.com/beacon.min.js...
The computed hash is "z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/..."
```

## Solution

Manually include the script without the `integrity` attribute. Disable auto-injection in Cloudflare dashboard (switch to "JS Snippet" mode).

## Note

Issue #25 described API route CORS configuration, but the actual error was this SRI mismatch - not related to API CORS at all. Closing #25 as the original concern is resolved.

Closes #25