### PR TITLE
feat: add GHCR publish workflow and Watchtower auto-deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_BASE: ghcr.io/davidlbowman/spotify-pomodoro
+  IMAGE_BASE: ghcr.io/dlb-technologies-llc/spotify-pomodoro
 
 jobs:
   build-and-push:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   app:
     build: .
-    image: ghcr.io/davidlbowman/spotify-pomodoro:${IMAGE_TAG:-latest}
+    image: ghcr.io/dlb-technologies-llc/spotify-pomodoro:${IMAGE_TAG:-latest}
     labels:
       com.centurylinklabs.watchtower.enable: "true"
     ports:


### PR DESCRIPTION
## Summary

Closes #29

- Add GitHub Actions workflow (`deploy.yml`) that builds and pushes the Docker image to GHCR on every push to `main`, tagged with `latest` + short SHA
- Update `docker-compose.yml` with GHCR image reference and Watchtower label for automatic VPS deployments

## Changes

- **`.github/workflows/deploy.yml`** (new): Build and push to `ghcr.io/dlb-technologies-llc/spotify-pomodoro` using `docker/build-push-action@v6` with Buildx. Only uses `GITHUB_TOKEN` — no VPS secrets needed.
- **`docker-compose.yml`**: Added `image:` alongside `build:` (local `--build` still works), added Watchtower label `com.centurylinklabs.watchtower.enable: "true"`

## Post-merge manual steps

- [ ] Make the GHCR package public: GitHub → Packages → `spotify-pomodoro` → Package settings → Change visibility → Public
- [ ] On VPS, update `/srv/apps/spotify-pomodoro/docker-compose.yml` to match (or pull this repo)
- [ ] Ensure `IMAGE_TAG=latest` in infra `.env` (or omit — defaults to `latest`)

## Test Plan

- [ ] Workflow triggers only on push to `main`
- [ ] Image pushed with both `latest` and short SHA tags
- [ ] `setup-buildx-action` runs before `build-push-action`
- [ ] No secrets beyond `GITHUB_TOKEN`
- [ ] Both `build:` and `image:` present in compose
- [ ] Watchtower label present
- [ ] `bun run docker:prod` still builds locally (existing behavior preserved)

---
*Generated by `/execute` from plan: `~/c0de/plans/spotify-pomodoro/docker-cicd-ghcr.md`*