### PR TITLE
fix: post-upgrade fixes for Astro 6, React 19.2, deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,7 @@
 import node from "@astrojs/node";
 import react from "@astrojs/react";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig, sessionDrivers } from "astro/config";
+import { defineConfig } from "astro/config";
 
 // https://astro.build/config
 export default defineConfig({
@@ -9,9 +9,6 @@ export default defineConfig({
 	adapter: node({
 		mode: "standalone",
 	}),
-	session: {
-		driver: sessionDrivers.fs(),
-	},
 	server: {
 		port: 2500,
 	},

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -29,7 +29,7 @@ export function Login({ returnUrl = "/" }: LoginProps) {
 	const [error, setError] = useState<string | null>(null);
 	const [isLoading, setIsLoading] = useState(false);
 
-	const handleSubmit = async (e: React.FormEvent) => {
+	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		setError(null);
 		setIsLoading(true);


### PR DESCRIPTION
## Summary

Fix three issues discovered after the Astro 6.0 dependency upgrade (#33):

- **fix-astro-session-config**: Remove broken `sessionDrivers` import from `astro.config.mjs` — the export doesn't exist in Astro 6.0.3 despite being documented. The `@astrojs/node` adapter auto-configures `fs-lite` session storage. (Refs #31)
- **fix-react-form-event**: Replace deprecated `React.FormEvent` with `React.FormEvent<HTMLFormElement>` in Login.tsx. (Refs #34)
- **add-node-setup-deploy**: Add `actions/setup-node@v4` with Node 24 to deploy workflow for consistency with CI. (Refs #35)

## Test Plan

- [ ] `bun run build` succeeds (was broken before this PR)
- [ ] `bun run typecheck` succeeds (was broken before this PR)
- [ ] `bun run test` — all 60 tests pass
- [ ] OAuth PKCE flow still works (session handled by adapter default)
- [ ] Deploy workflow YAML is valid

Closes #31, Closes #34, Closes #35

---
*Generated by `/execute` from plan: `~/c0de/plans/spotify-pomodoro/post-upgrade-fixes.md`*