### PR TITLE
chore: pre-release cleanup (Refs #38, #39, #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ A self-hosted pomodoro timer with Spotify integration and a lofi aesthetic. Focu
 
 - Timer presets: Short (15/3), Classic (25/5), Long (50/10)
 - Overtime mode - timer counts up after completion, you decide when to switch
-- Session statistics - track your focus time, streaks, and overtime
-- Spotify integration with playlist selection
+- Stop button to end sessions without auto-transitioning to the next phase
+- Session statistics with contribution graph - track your focus time, streaks, and overtime
+- Spotify integration with playlist selection and Web Playback SDK (play directly in the browser without needing an external Spotify app)
+- Structured logging with configurable levels and format (pretty or JSON)
 - Light/dark theme toggle
 - Keyboard-first controls
 
@@ -20,7 +22,7 @@ A self-hosted pomodoro timer with Spotify integration and a lofi aesthetic. Focu
 3. Fill in the details:
    - **App name:** Spotify Pomodoro
    - **Redirect URI:** See setup options below
-   - **APIs used:** Check "Web API"
+   - **APIs used:** Check "Web API" and "Web Playback SDK"
 4. Copy the **Client ID** from your app's settings
 
 ### 2. Choose Your Setup
@@ -98,12 +100,13 @@ When enabled, all routes require login. The login page appears at `/login`.
 
 ## Keyboard Controls
 
-| Key               | Action                                       |
-| ----------------- | -------------------------------------------- |
-| `Space` / `Enter` | Start timer                                  |
-| `E`               | End current session early (during countdown) |
-| `S`               | Skip to next phase (during overtime)         |
-| `R`               | Reset timer (when stopped)                   |
+| Key               | Action                              |
+| ----------------- | ----------------------------------- |
+| `Space` / `Enter` | Start timer                         |
+| `E`               | End (stop) current session          |
+| `B`               | Skip to break (during focus)        |
+| `F`               | Skip to focus (during break)        |
+| `R`               | Reset timer (when stopped)          |
 
 ## Local Development
 
@@ -150,7 +153,7 @@ Ensure the redirect URI in your Spotify app settings exactly matches `PUBLIC_SPO
 
 ### "No active device"
 
-Spotify requires an active device to control playback. Open Spotify on your computer or phone before selecting a playlist.
+The app includes a built-in Web Playback SDK player, so playback works directly in the browser. If you see this error, make sure the browser tab has focus and try refreshing. Alternatively, open Spotify on your computer or phone to use it as the playback device.
 
 ### Container health check failing
 

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -29,7 +29,7 @@ export function Login({ returnUrl = "/" }: LoginProps) {
 	const [error, setError] = useState<string | null>(null);
 	const [isLoading, setIsLoading] = useState(false);
 
-	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+	const handleSubmit = async (e: React.SubmitEvent) => {
 		e.preventDefault();
 		setError(null);
 		setIsLoading(true);

--- a/src/pages/api/auth/init.ts
+++ b/src/pages/api/auth/init.ts
@@ -59,8 +59,8 @@ export const GET: APIRoute = async ({ session }) => {
 
 	const state = randomUUID();
 
-	await session.set("pkce_verifier", verifier);
-	await session.set("pkce_state", state);
+	session.set("pkce_verifier", verifier);
+	session.set("pkce_state", state);
 
 	const params = new URLSearchParams({
 		client_id: SPOTIFY_CLIENT_ID,

--- a/src/pages/callback.ts
+++ b/src/pages/callback.ts
@@ -82,8 +82,8 @@ export const GET: APIRoute = async ({ url, session, redirect }) => {
 			scope: string;
 		};
 
-		await session.delete("pkce_verifier");
-		await session.delete("pkce_state");
+		session.delete("pkce_verifier");
+		session.delete("pkce_state");
 
 		const token = {
 			accessToken: tokenData.access_token,


### PR DESCRIPTION
## Summary

Final cleanup before staging→main release:
- Remove unnecessary `await` on Astro 6 sync session methods (#38)
- Replace deprecated `React.FormEvent` with `React.SubmitEvent` (#39)
- Update README for accuracy: keyboard controls, features, Web Playback SDK (#26)

## Completed Tasks

- [x] **remove-session-await**: Remove `await` from 4 Astro 6 sync session calls
- [x] **replace-form-event**: Replace deprecated `React.FormEvent<HTMLFormElement>` with `React.SubmitEvent`
- [x] **readme-accuracy**: Update README features, keyboard controls, and troubleshooting

## Test Plan

- [ ] `bun run typecheck` passes with 0 errors, 0 warnings (no `ts(80007)` or `ts(6385)`)
- [ ] OAuth flow works (login via Spotify still functions)
- [ ] Login form submits correctly
- [ ] Keyboard controls match README: Space/Enter=start, E=stop, B=break, F=focus, R=reset
- [ ] All 93 tests pass

Refs #38, Refs #39, Refs #26

---
*Generated by `/execute` from plan: `~/c0de/plans/spotify-pomodoro/pre-release-cleanup.md`*