### PR TITLE
fix: add Content-Type header to no-body POST calls

### DIFF
--- a/src/lib/sessionApi.ts
+++ b/src/lib/sessionApi.ts
@@ -56,6 +56,7 @@ export async function createPomodoro(): Promise<PomodoroEncoded> {
 		"/api/pomodoros",
 		{
 			method: "POST",
+			headers: { "Content-Type": "application/json" },
 		},
 	);
 	if (!response.ok) {
@@ -74,7 +75,7 @@ export async function completePomodoro(id: string): Promise<PomodoroEncoded> {
 	const response = await tracedFetch(
 		"session.completePomodoro",
 		`/api/pomodoros/${id}/complete`,
-		{ method: "POST" },
+		{ method: "POST", headers: { "Content-Type": "application/json" } },
 	);
 	if (!response.ok) {
 		throw new Error(`Failed to complete pomodoro: ${response.statusText}`);


### PR DESCRIPTION
## Summary

Closes #55

`createPomodoro()` and `completePomodoro()` in `sessionApi.ts` sent POST requests without `Content-Type: application/json`. Astro's CSRF protection rejects POSTs without a JSON content type, returning 403.

## Test plan

- [ ] `curl -X POST https://pomodoro.theinnovationlab.dev/api/pomodoros` without Content-Type → 403 (before)
- [ ] Same call with `-H 'Content-Type: application/json'` → 201 (confirms the fix)
- [ ] Start a pomodoro in the UI → network tab shows 201 not 403