### PR TITLE
fix: dynamically size minutes display for 3+ digit overtime

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -222,7 +222,12 @@ export function App() {
 						>
 							{sign && <span className="animate-pulse-soft">{sign}</span>}
 
-							<span className="digit-transition inline-block w-[1.4em] text-center">
+							<span
+								className={cn(
+									"digit-transition inline-block text-center",
+									minutes.length > 2 ? "w-[2.1em]" : "w-[1.4em]",
+								)}
+							>
 								{minutes}
 							</span>
 


### PR DESCRIPTION
## Summary
- Minutes span had fixed `w-[1.4em]` width (2 digits). At 100+ minutes overtime (e.g. `+115:52`), the last digit overlaps the colon separator.
- Dynamically widen to `w-[2.1em]` when `minutes.length > 2`.

Closes #56

## Test plan
- [ ] Run `bun run dev`, start a focus timer, let it run into overtime past 99 minutes
- [ ] Verify colon and digits don't overlap at 3-digit values
- [ ] Verify normal 2-digit display is unchanged